### PR TITLE
Atrybut do weryfikacji blokady userów

### DIFF
--- a/Backend/BackendAPI/Controllers/BikesController.cs
+++ b/Backend/BackendAPI/Controllers/BikesController.cs
@@ -52,10 +52,9 @@ namespace BackendAPI.Controllers
         /// 
         /// </summary>
         [HttpPost("rented")]
+        [NotForBlocked]
         public ActionResult<BikeDTO> RentedPost([FromBody] IdDTO rent)
         {
-            //[BLOCKED] dopisac check na zablokowanego uzytkownika
-
             Bike bike;
             if (!int.TryParse(rent.Id, out int bikeId) || 
                 (bike = bikeRepository.GetByID(bikeId)) == null)

--- a/Backend/BackendAPI/Controllers/StationsController.cs
+++ b/Backend/BackendAPI/Controllers/StationsController.cs
@@ -61,7 +61,7 @@ namespace BackendAPI.Controllers
         }
 
 
-        [HttpGet("bikes/{id}")]
+        [HttpGet("{id}/bikes")]
         public IActionResult GetBikes(string id)
         {
             BikeStation station;
@@ -78,7 +78,7 @@ namespace BackendAPI.Controllers
             return Ok(new { Bikes = bikes } );
         }
 
-        [HttpPost("bikes/{id}")]
+        [HttpPost("{id}/bikes")]
         public ActionResult<BikeDTO> PostBike(string id, [FromBody] IdDTO bikeIdObj)
         {
             BikeStation station;

--- a/Backend/BackendAPI/Controllers/StationsController.cs
+++ b/Backend/BackendAPI/Controllers/StationsController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Security.Claims;
+using BackendAPI.Helpers;
 using BackendAPI.Helpers.DTOFactories;
 using BackendAPI.Models;
 using BackendAPI.Repository.Interfaces;

--- a/Backend/BackendAPI/Helpers/NotForBlockedAttribute.cs
+++ b/Backend/BackendAPI/Helpers/NotForBlockedAttribute.cs
@@ -1,0 +1,22 @@
+﻿using BackendAPI.Models;
+using BackendAPI.Repository.Interfaces;
+using ClassLibrary.Exceptions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+public class NotForBlockedAttribute: Attribute, IAuthorizationFilter
+{
+    public void OnAuthorization(AuthorizationFilterContext context)
+    {
+        var blocked = context.HttpContext.User?.FindFirstValue("Blocked");
+        if (blocked == bool.TrueString)
+            context.Result = new JsonResult(new { Message = "User has been blocked" }) { StatusCode = 403 };
+    }
+}
+

--- a/Backend/BackendAPI/Migrations/20210419212240_AddedBlockedProperty.Designer.cs
+++ b/Backend/BackendAPI/Migrations/20210419212240_AddedBlockedProperty.Designer.cs
@@ -4,14 +4,16 @@ using BackendAPI.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace BackendAPI.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20210419212240_AddedBlockedProperty")]
+    partial class AddedBlockedProperty
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Backend/BackendAPI/Migrations/20210419212240_AddedBlockedProperty.cs
+++ b/Backend/BackendAPI/Migrations/20210419212240_AddedBlockedProperty.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace BackendAPI.Migrations
+{
+    public partial class AddedBlockedProperty : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "Blocked",
+                table: "Users",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.UpdateData(
+                table: "Users",
+                keyColumn: "ID",
+                keyValue: 4,
+                column: "Blocked",
+                value: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Blocked",
+                table: "Users");
+        }
+    }
+}

--- a/Backend/BackendAPI/Models/User.cs
+++ b/Backend/BackendAPI/Models/User.cs
@@ -21,5 +21,7 @@ namespace BackendAPI.Models
         public string Login { get; set; }
         [JsonIgnore] //żeby przy serializacji do jsona się nie serializowało]  
         public string PasswordHash { get; set; }
+
+        public bool Blocked { get; set; }
     }
 }

--- a/Backend/BackendAPI/ModelsConfigurations/UserConfiguration.cs
+++ b/Backend/BackendAPI/ModelsConfigurations/UserConfiguration.cs
@@ -29,7 +29,7 @@ namespace BackendAPI.ModelsConfigurations
                 new User { ID = 1, Name = "ImieTestowe", LastName = "NazwiskoTestowe", Login = "login1", PasswordHash = stringHash.GetHash("pass1"), Role=Role.User },
                 new User { ID = 2, Name = "Imie2", LastName = "Nazwisko2", Login = "login2", PasswordHash = stringHash.GetHash("pass2"), Role = Role.User },
                 new User { ID = 3, Name = "Grzegorz", LastName = "Brzęczeszykiewicz", Login = "login3", PasswordHash = stringHash.GetHash("pass3"), Role = Role.User },
-                new User { ID = 4, Name = "Imie3", LastName = "Nazwisko3", Login = "login4", PasswordHash = stringHash.GetHash("pass4"), Role = Role.User },
+                new User { ID = 4, Name = "Imie3", LastName = "Nazwisko3", Login = "login4", PasswordHash = stringHash.GetHash("pass4"), Role = Role.User, Blocked = true },
                 new User { ID = 5, Name = "PostmanUserName", LastName = "PostmanUserLastName", Login = "PostmanUser", PasswordHash = stringHash.GetHash("PostmanUserPass"), Role = Role.User },
                 new User { ID = 6, Name = "PostmanAdminName", LastName = "PostmanAdminLastName", Login = "PostmanAdmin", PasswordHash = stringHash.GetHash("PostmanAdminPass"), Role = Role.Admin},
                 new User { ID = 7, Name = "PostmanTechName", LastName = "PostmanTechLastName", Login = "PostmanTech", PasswordHash = stringHash.GetHash("PostmanTechPass"), Role = Role.Tech },

--- a/Backend/BackendAPI/Repository/Repositories/UserRepository.cs
+++ b/Backend/BackendAPI/Repository/Repositories/UserRepository.cs
@@ -55,6 +55,8 @@ namespace BackendAPI.Repository.Repositories
                     {
                         new Claim(ClaimTypes.NameIdentifier, user.ID.ToString()),
                         new Claim(ClaimTypes.Role, user.Role),
+                        //Jeśli user jest userem zwykłym i jest zablokowany
+                        new Claim("Blocked", (user.Role == Role.User && user.Blocked).ToString())
                     }),
                 Expires = DateTime.UtcNow.AddHours(1),
                 SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(key), SecurityAlgorithms.HmacSha256Signature)


### PR DESCRIPTION
![obraz](https://user-images.githubusercontent.com/69988486/115306027-84ffeb80-a167-11eb-8cc4-0c9ad60dd650.png)

Przykłąd zastosowania na screeenie. Dodam jeszcze, że może kolejnośc używania [NotForBlcooked] i [Authorize] jest ważna, więc chyba lepiej używać authorize przed [NotForBlocked]. Ponadto, specjalnie nie ma namespace na NotForBlocked jbc

Admina i techa nie da się zablokować, tzn. nawet jak majaBlocked=true to i tak na nich to nie działa

UWAGA! W atrybucie ręcznie zwracam jsonresult a nie z wykorzystaniem ExceptionFilter rzucam wyjątek, bo na tym poziomie exceptionfilter nie działa (to jest chyba przed warstwą na której działa exceptionfilter)