### PR TITLE
Atrybut NotForBlocked, by na bieżąco sprawdzał blokadę usera

### DIFF
--- a/Backend/BackendAPI/Services/Classes/LoginService.cs
+++ b/Backend/BackendAPI/Services/Classes/LoginService.cs
@@ -86,8 +86,6 @@ namespace BackendAPI.Services.Classes
                     {
                         new Claim(ClaimTypes.NameIdentifier, user.ID.ToString()),
                         new Claim(ClaimTypes.Role, user.Role),
-                        //Jeśli user jest userem zwykłym i jest zablokowany
-                        new Claim("Blocked", (user.Role == Role.User && user.Blocked).ToString())
                     }),
                 Expires = DateTime.UtcNow.AddHours(1),
                 SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(key), SecurityAlgorithms.HmacSha256Signature)


### PR DESCRIPTION
Przy próbie dostępu do endpointa [NotForBlocked] sprawdza blokadę i w razie czego wywala odpowiedni response. Wcześniej informacja o blokadzie była w Claimach, co było złe, gdyż po zablokowaniu użytkownik nadal do końca swojej bieżącej sesji mógł działać normalnie.