### PR TITLE
Dodanie skryptu automatyzujacego testy

### DIFF
--- a/Backend/BackendAPI/BackendAPI.csproj
+++ b/Backend/BackendAPI/BackendAPI.csproj
@@ -35,7 +35,7 @@
     <ProjectReference Include="..\..\Libraries\ClassLibrary\ClassLibrary.csproj" />
   </ItemGroup>
 
-  <PropertyGroup>
+  <!--<PropertyGroup>
    <_OutputCopyLocation>$(SolutionDir)Output\$(Configuration)\BackendAPI\</_OutputCopyLocation>
   </PropertyGroup>
 
@@ -54,6 +54,6 @@
       <_CustomFilesToDelete Include="$(_OutputCopyLocation)**\*" />
     </ItemGroup>
     <Delete Files="@(_CustomFilesToDelete)" />
-  </Target>
+  </Target>-->
 
 </Project>

--- a/scripts/run_test.ps1
+++ b/scripts/run_test.ps1
@@ -1,0 +1,35 @@
+﻿if ( $args.Count -ne 2 )
+{
+    Write-Host "Usage:" $MyInvocation.MyCommand.Name "solution_directory test_file"
+    Write-Host "solution_directory - root directory of solution"
+    Write-Host "test_file - path to Postman test collection"
+    exit 1
+}
+
+$solution = $args[0]
+$test = $args[1]
+$start = $PWD.Path
+
+Write-Host "Preparing backend app and database."
+cd $solution
+dotnet clean
+dotnet build --no-restore
+cd Backend\BackendAPI\
+dotnet ef database update 0 --no-build --context BackendAPI.Data.DataContext
+dotnet ef database update --no-build --context BackendAPI.Data.DataContext
+
+Write-Host "Starting backend."
+cd $start
+$dotnet = "dotnet"
+$dotnet_args = "run -p " + $solution + "\Backend\BackendAPI\BackendApi.csproj"
+$backend = Start-Process $dotnet $dotnet_args -PassThru
+Start-Sleep 5
+
+Write-Host "Running tests."
+newman run $test --insecure
+
+if ( $backend.HasExited -eq 0 )
+{
+    Write-HOst "Stoping backend."
+    Stop-Process $backend.Id
+}


### PR DESCRIPTION
Usunąłem folder Output i całe kopiowanie tam - psuł krew przy poleceniach dotnetowych.
Skryptu używa się bardzo prosto.
Podajemy mu dwa argumenty:
* ścieżkę do folderu z całym naszym projektem (czyli do folderu gdzie jest plik.sln)
* ścieżkę do kolekcji w jsonie, która ma wykonać
Skrypt sam dba o dobry stan bazy i uruchomienie backendu.